### PR TITLE
Cast logits to fp32 before log_softmax in _logits_to_logprobs (fixes #21)

### DIFF
--- a/biofoundation/model/scoring.py
+++ b/biofoundation/model/scoring.py
@@ -124,8 +124,12 @@ def _logits_to_logprobs(
     Computes the log-likelihoods using a softmax along the vocab dimension.
     Uses the `input_ids` to index into the log-likelihoods and returns the likelihood
     of the provided sequence at each position with dimension (batch, length-1).
+
+    Logits are cast to fp32 before log_softmax: bf16 log_softmax has
+    ~10^-3 per-token rounding error that compounds across the sequence
+    sum in ``_clm_seq_logprob`` (see issue #21).
     """
-    softmax_logprobs = torch.log_softmax(logits, dim=-1)
+    softmax_logprobs = torch.log_softmax(logits.float(), dim=-1)
     softmax_logprobs = softmax_logprobs[:, :-1]
     input_ids = input_ids[:, 1:]
     assert softmax_logprobs.shape[1] == input_ids.shape[1]

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -20,7 +20,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from biofoundation.inference import run_ll_clm
 from biofoundation.model.adapters.hf import HFCausalLM, HFTokenizer
 from biofoundation.model.base import CausalLM
-from biofoundation.model.scoring import compute_ll_clm
+from biofoundation.model.scoring import _logits_to_logprobs, compute_ll_clm
 
 
 TINY_CLM = "hf-internal-testing/tiny-random-GPTNeoXForCausalLM"
@@ -178,7 +178,9 @@ def test_compute_ll_clm_dataset_wide_token_weighted_mean():
     is_upper[2, :2] = True
     is_upper[3, :9] = True
 
-    out = compute_ll_clm(model, input_ids, is_upper).double()  # cast for fp64 accumulate
+    out = compute_ll_clm(
+        model, input_ids, is_upper
+    ).double()  # cast for fp64 accumulate
     S_u, S_l, n_u, n_l = out.sum(dim=0).unbind(-1)
     LL_all = ((S_u + S_l) / (n_u + n_l)).item()
     LL_upper = (S_u / n_u).item()
@@ -216,7 +218,7 @@ def test_compute_ll_clm_all_upper_or_all_lower_rows_aggregate_correctly():
     model = _DeterministicCLM(logits)
 
     is_upper = torch.zeros(B, L, dtype=torch.bool)
-    is_upper[0, :] = True   # row 0: all upper (target frame too)
+    is_upper[0, :] = True  # row 0: all upper (target frame too)
     # row 1: all lower (default)
     is_upper[2, :3] = True  # row 2: mixed
 
@@ -248,6 +250,43 @@ def test_compute_ll_clm_shape_without_mask():
     out = compute_ll_clm(model, input_ids)
     assert out.shape == (B, 2)
     assert torch.all(out[:, 1] == float(L - 1))
+
+
+def test_logits_to_logprobs_promotes_bf16_to_fp32():
+    """Regression test for #21: log_softmax must run in fp32 even when
+    the model returns bf16 logits, so per-token bf16 rounding error does
+    not compound across the sequence sum.
+
+    Starting from the same bf16-rounded logits, the fp32-internal path
+    (the fix) must produce a sequence-summed log-prob closer to the full
+    fp32 reference than the bf16-internal path (the unfixed code) does.
+    """
+    torch.manual_seed(0)
+    B, L, V = 2, 256, 6  # T=256 from the issue's measurement
+    fp32_logits = torch.randn(B, L, V) * 5
+    bf16_logits = fp32_logits.to(torch.bfloat16)
+    input_ids = torch.randint(0, V, (B, L))
+
+    # The fix: fp32 internal even from bf16 input.
+    logp_fixed = _logits_to_logprobs(bf16_logits, input_ids)
+    assert logp_fixed.dtype == torch.float32
+
+    # Full fp32 path (best attainable given fp32 logits).
+    logp_fp32 = _logits_to_logprobs(fp32_logits, input_ids)
+
+    # Unfixed path: log_softmax in bf16 (inline reproduction).
+    softmax_bf16 = torch.log_softmax(bf16_logits, dim=-1)[:, :-1]
+    targets = input_ids[:, 1:]
+    logp_unfixed = (
+        torch.gather(softmax_bf16, 2, targets.unsqueeze(-1)).squeeze(-1).float()
+    )
+
+    err_fixed = (logp_fixed.sum(-1) - logp_fp32.sum(-1)).abs().max().item()
+    err_unfixed = (logp_unfixed.sum(-1) - logp_fp32.sum(-1)).abs().max().item()
+    # The unfixed path compounds bf16 log_softmax error across L-1
+    # positions on top of input-rounding error; the fix only carries the
+    # latter.
+    assert err_fixed < err_unfixed
 
 
 def test_run_ll_clm_end_to_end():


### PR DESCRIPTION
## Summary

- Cast logits to fp32 before `log_softmax` in `_logits_to_logprobs` so the per-token softmax runs in fp32 even when the model returns bf16 (the default under `bf16_full_eval=True`).
- All CLM scoring entry points (`compute_llr_clm`, `compute_reflogprob_clm`, `compute_ll_clm`, `compute_llr_and_embedding_distance`) route through this helper and pick up the fix transparently. MLM functions are unaffected (no compounded sum).
- Add a regression test that compares the fp32-internal path against an inline reproduction of the unfixed bf16-internal path, starting from the same bf16-rounded logits.

Fixes #21.

## Why this matters (from the issue)

bf16 `log_softmax` has ~10⁻³ per-token rounding error that compounds across the T−1 positions of the sequence sum in `_clm_seq_logprob`:

- Median absolute LLR error vs. fp32: 0.055
- Worst-case absolute LLR error: 0.625 (≈80% relative on small-|LLR| variants)
- 23 / 1128 LLR sign flips
- 19 / 564 (3.4%) matched-pair order flips in `evals_v2` PairwiseAccuracy

Pearson stays at 0.9996, so ranking is mostly preserved — but at small-N matched-pair evals the 3.4% pair-flip rate sits at the SE noise floor. This fix removes that floor.

## Implementation choice

Kept the existing `log_softmax` + `gather` flow with a one-token cast (`logits.float()`). At DNA vocab sizes (V=6) the resulting fp32 softmax tensor is ~0.4 MB at typical batch×length, so memory isn't a concern. Matches the file's idiom (`compute_reflogprob_mlm` and `compute_reflogprob_clm` use `log_softmax` too) and keeps `test_compute_ll_clm_matches_hf_cross_entropy` as a genuine independent cross-check against HF's `F.cross_entropy`-based loss.

If a large-vocab model (e.g. Qwen3 V=151K, ~10 GB fp32 softmax at B=64, T=256) is ever routed through this path, switching to `F.cross_entropy(reduction="none")` is a clean follow-up.

## Test plan

- [x] `pytest tests/test_scoring.py` — 9 passed (new bf16-promotion regression test included)
- [x] `ruff check biofoundation/model/scoring.py tests/test_scoring.py` — clean
- [x] `ruff format --check biofoundation/model/scoring.py tests/test_scoring.py` — clean
- [x] `mypy biofoundation` — clean

## Downstream caveat (per issue author)

`evals_v2` public leaderboards in bolinas-dna (#161/#162/#172) will shift by <1 pair per subset when bolinas is re-pinned to a biofoundation version with this fix. That re-pin is a separate decision and not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)