### PR TITLE
Replace eager FASTA load with pyfaidx-backed lazy access (fixes #23)

### DIFF
--- a/biofoundation/data.py
+++ b/biofoundation/data.py
@@ -1,14 +1,15 @@
 import functools
-import gzip
+import os
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal
+from urllib.parse import urlparse
 
 import bioframe as bf
 import numpy as np
 import pandas as pd
 import torch
-from Bio import SeqIO
 from Bio.Seq import Seq
+from pyfaidx import Fasta
 
 from biofoundation.model.base import Tokenizer
 
@@ -19,15 +20,60 @@ VARIANT_COORDS = ["chrom", "pos", "ref", "alt"]
 
 
 class Genome:
+    """Random-access FASTA reader backed by :mod:`pyfaidx`.
+
+    Sequences are read on demand from the FASTA file rather than loaded into
+    memory upfront, so ``Genome(...)`` is fast to construct and uses
+    near-zero baseline memory.
+
+    A samtools-compatible ``.fai`` index is required. For local files, pyfaidx
+    creates one next to the FASTA on first open. For remote paths
+    (e.g. ``s3://``), the ``.fai`` must already exist alongside the FASTA.
+
+    Gzipped FASTA input must be **bgzipped** (BGZF, with a ``.gzi``
+    companion). Plain gzip is not supported — re-compress with ``bgzip``.
+
+    Remote paths (``s3://``, etc.) require the optional ``s3`` extra
+    (``pip install -e .[s3]``), which pulls in ``fsspec`` and ``s3fs``.
+
+    Args:
+        path: Local filesystem path or fsspec-compatible URL.
+        subset_chroms: If given, only chromosomes in this set are exposed.
+    """
+
     def __init__(
         self,
         path: str | Path,
         subset_chroms: set[str] | None = None,
     ):
-        self._genome: pd.Series = read_fasta(path, subset_chroms=subset_chroms)
-        self._chrom_sizes: dict[str, int] = {
-            chrom: len(seq) for chrom, seq in self._genome.items()
-        }
+        self._path: str = str(path)
+        self._is_remote: bool = urlparse(self._path).scheme not in ("", "file")
+        self._subset_chroms = subset_chroms
+
+        # Probe once to capture chromosome sizes, then close so no live fd
+        # is inherited across fork() into DataLoader workers.
+        with self._open_fasta() as fa:
+            keys = [k for k in fa.keys() if subset_chroms is None or k in subset_chroms]
+            self._chrom_sizes: dict[str, int] = {k: len(fa[k]) for k in keys}
+
+        # Per-process Fasta handle, opened lazily on first __call__.
+        self._fa: Fasta | None = None
+        self._fa_pid: int = -1
+
+    def _open_fasta(self) -> Fasta:
+        if self._is_remote:
+            import fsspec
+
+            return Fasta(fsspec.open(self._path), as_raw=True)
+        return Fasta(self._path, as_raw=True)
+
+    def _fasta(self) -> Fasta:
+        # Reopen when we cross a process boundary (fork or spawn).
+        pid = os.getpid()
+        if self._fa is None or self._fa_pid != pid:
+            self._fa = self._open_fasta()
+            self._fa_pid = pid
+        return self._fa
 
     def __call__(
         self,
@@ -47,7 +93,7 @@ class Genome:
             end: The end position of the sequence (0-based, exclusive).
             strand: The strand of the sequence (+ or -).
         """
-        if chrom not in self._genome:
+        if chrom not in self._chrom_sizes:
             raise ValueError(f"chromosome {chrom} not found in genome")
         chrom_size = self._chrom_sizes[chrom]
         if strand not in {"+", "-"}:
@@ -59,7 +105,7 @@ class Genome:
         if start >= chrom_size:
             raise ValueError(f"start {start} is out of range for chromosome {chrom}")
 
-        seq = self._genome[chrom][max(start, 0) : min(end, chrom_size)]
+        seq: str = self._fasta()[chrom][max(start, 0) : min(end, chrom_size)]
 
         if start < 0:
             seq = "N" * (-start) + seq  # left padding
@@ -68,7 +114,14 @@ class Genome:
 
         if strand == "-":
             seq = str(Seq(seq).reverse_complement())  # type: ignore[no-untyped-call]
-        return cast(str, seq)
+        return seq
+
+    def __getstate__(self) -> dict[str, Any]:
+        # Don't pickle the live Fasta handle: its fd is invalid in a spawn worker.
+        state = self.__dict__.copy()
+        state["_fa"] = None
+        state["_fa_pid"] = -1
+        return state
 
 
 class GenomicSet:
@@ -462,18 +515,3 @@ def transform_ll_clm(
         input_ids=torch.tensor(full_ids, dtype=torch.long),
         is_upper=torch.tensor(is_upper, dtype=torch.bool),
     )
-
-
-def read_fasta(
-    path: str | Path,
-    subset_chroms: set[str] | None = None,
-) -> pd.Series:
-    with gzip.open(path, "rt") if str(path).endswith(".gz") else open(path) as handle:
-        genome = pd.Series(
-            {
-                rec.id: str(rec.seq)
-                for rec in SeqIO.parse(handle, "fasta")  # type: ignore[no-untyped-call]
-                if subset_chroms is None or rec.id in subset_chroms
-            }
-        )
-    return genome

--- a/biofoundation/data.py
+++ b/biofoundation/data.py
@@ -52,7 +52,7 @@ class Genome:
     ):
         self._path: str = str(path)
         self._is_remote: bool = urlparse(self._path).scheme not in ("", "file")
-        self._storage_options: dict[str, Any] = storage_options or {}
+        self._storage_options: dict[str, Any] = dict(storage_options or {})
 
         # Probe once to capture chromosome sizes, then close so no live fd
         # is inherited across fork() into DataLoader workers.

--- a/biofoundation/data.py
+++ b/biofoundation/data.py
@@ -48,7 +48,6 @@ class Genome:
     ):
         self._path: str = str(path)
         self._is_remote: bool = urlparse(self._path).scheme not in ("", "file")
-        self._subset_chroms = subset_chroms
 
         # Probe once to capture chromosome sizes, then close so no live fd
         # is inherited across fork() into DataLoader workers.
@@ -56,7 +55,6 @@ class Genome:
             keys = [k for k in fa.keys() if subset_chroms is None or k in subset_chroms]
             self._chrom_sizes: dict[str, int] = {k: len(fa[k]) for k in keys}
 
-        # Per-process Fasta handle, opened lazily on first __call__.
         self._fa: Fasta | None = None
         self._fa_pid: int = -1
 
@@ -68,7 +66,6 @@ class Genome:
         return Fasta(self._path, as_raw=True)
 
     def _fasta(self) -> Fasta:
-        # Reopen when we cross a process boundary (fork or spawn).
         pid = os.getpid()
         if self._fa is None or self._fa_pid != pid:
             self._fa = self._open_fasta()

--- a/biofoundation/data.py
+++ b/biofoundation/data.py
@@ -39,15 +39,20 @@ class Genome:
     Args:
         path: Local filesystem path or fsspec-compatible URL.
         subset_chroms: If given, only chromosomes in this set are exposed.
+        storage_options: Forwarded to ``fsspec.open`` for remote paths
+            (e.g. ``{"anon": True}`` for public S3 buckets). Ignored for
+            local paths.
     """
 
     def __init__(
         self,
         path: str | Path,
         subset_chroms: set[str] | None = None,
+        storage_options: dict[str, Any] | None = None,
     ):
         self._path: str = str(path)
         self._is_remote: bool = urlparse(self._path).scheme not in ("", "file")
+        self._storage_options: dict[str, Any] = storage_options or {}
 
         # Probe once to capture chromosome sizes, then close so no live fd
         # is inherited across fork() into DataLoader workers.
@@ -62,7 +67,7 @@ class Genome:
         if self._is_remote:
             import fsspec
 
-            return Fasta(fsspec.open(self._path), as_raw=True)
+            return Fasta(fsspec.open(self._path, **self._storage_options), as_raw=True)
         return Fasta(self._path, as_raw=True)
 
     def _fasta(self) -> Fasta:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "numpy",
     "pandas",
     "pyarrow>=21.0.0",
+    "pyfaidx>=0.8.0",
     "scikit-learn",
     "transformers[torch]",
     "bioframe",
@@ -31,6 +32,10 @@ gpn = [
 glm-experiments = [
   "lightning>=2.0.0",
   "hydra-core>=1.3.0,<2.0.0",
+]
+s3 = [
+  "fsspec>=2024.0.0",
+  "s3fs",
 ]
 
 [tool.uv.sources]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -675,6 +675,28 @@ def test_genome_ignores_storage_options_for_local_paths(tmp_path):
     assert genome("chr1", start=2, end=7) == "GTACG"
 
 
+def test_genome_forwards_storage_options_to_fsspec(monkeypatch):
+    fsspec = pytest.importorskip("fsspec")
+
+    captured = {}
+
+    class _Sentinel(Exception):
+        pass
+
+    def fake_open(path, **kwargs):
+        captured.update(path=path, kwargs=kwargs)
+        raise _Sentinel
+
+    monkeypatch.setattr(fsspec, "open", fake_open)
+
+    opts = {"anon": True, "endpoint_url": "https://example"}
+    with pytest.raises(_Sentinel):
+        Genome("s3://fake-bucket/x.fa", storage_options=opts)
+
+    assert captured["path"] == "s3://fake-bucket/x.fa"
+    assert captured["kwargs"] == {"anon": True, "endpoint_url": "https://example"}
+
+
 # GenomicSet tests
 def test_genomic_set_initialization_non_overlapping():
     """Test GenomicSet initialization with non-overlapping intervals.

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -655,6 +655,19 @@ def test_genome_respects_subset(tmp_path):
         genome("chr1", start=0, end=4)
 
 
+def test_genome_survives_pickle_roundtrip(tmp_path):
+    """A pickled Genome must work after unpickling (spawn-worker scenario)."""
+    import pickle
+
+    fasta_path = _write_genome_fasta(tmp_path)
+    genome = Genome(fasta_path)
+    assert genome("chr1", start=2, end=7) == "GTACG"  # populate _fa in parent
+
+    restored = pickle.loads(pickle.dumps(genome))
+    assert restored("chr1", start=2, end=7) == "GTACG"
+    assert restored("chr2", start=1, end=6, strand="-") == "GGGCC"
+
+
 # GenomicSet tests
 def test_genomic_set_initialization_non_overlapping():
     """Test GenomicSet initialization with non-overlapping intervals.

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -668,6 +668,13 @@ def test_genome_survives_pickle_roundtrip(tmp_path):
     assert restored("chr2", start=1, end=6, strand="-") == "GGGCC"
 
 
+def test_genome_ignores_storage_options_for_local_paths(tmp_path):
+    fasta_path = _write_genome_fasta(tmp_path)
+    genome = Genome(fasta_path, storage_options={"anon": True, "ignored": "kw"})
+
+    assert genome("chr1", start=2, end=7) == "GTACG"
+
+
 # GenomicSet tests
 def test_genomic_set_initialization_non_overlapping():
     """Test GenomicSet initialization with non-overlapping intervals.


### PR DESCRIPTION
## Summary

- Closes #23: `Genome.__call__` was per-element O(many μs) when the FASTA `pd.Series` got promoted to a pyarrow-backed string dtype (default behavior arriving in pandas 3.0). In a downstream variant-eval pipeline the GPU sat at 0% while Python pegged a core at 100%; reproducer in the issue shows ~5 calls/sec.
- Switch `Genome` to [pyfaidx](https://github.com/mdshw5/pyfaidx) (htslib-style random access via `.fai`). Construction is near-instant, baseline RAM drops from ~3 GB to tens of MB, and the per-call hot path no longer touches pandas/arrow.
- Adds optional `[s3]` extra (`fsspec` + `s3fs`) and a `storage_options=` kwarg so `Genome("s3://...", storage_options={"anon": True})` works against public buckets without downloading the whole FASTA. `.fai` must be pre-built on the remote.
- Worker-safe: per-PID handle cache + `__getstate__` re-opens the file in each fork/spawn worker (live `Fasta` handles are not pickled).
- Removes the now-unused `read_fasta` helper.

### Breaking change

Plain-gzipped FASTA is no longer accepted — pyfaidx requires **bgzipped** (BGZF, with `.gzi`). Users with plain `.gz` files should re-compress with `bgzip` (or pass the uncompressed FASTA). Documented in the new `Genome` docstring. Note: several `examples/*.py` reference the Ensembl plain-`.gz` GRCh38 — re-running those locally will need uncompressed or bgzipped input.

## Why pyfaidx (vs. just caching the resolved string)

Issue #23 proposed three fixes. I considered them all (research in the linked commits / plan):

1. In-class lazy `dict[str, str]` cache — tiniest diff, but still loads the whole genome upfront and doesn't help with S3.
2. Force object dtype in `read_fasta` — only addresses the symptom; future pandas behavior remains a risk.
3. **pyfaidx** — wins on hot-path speed, startup time, memory, and unlocks S3. Chosen.

The upstream pandas arrow path won't be optimized in time: closest tracker [pandas-dev/pandas#50121](https://github.com/pandas-dev/pandas/issues/50121) is still open and the cost is structural at the Arrow→Python FFI boundary.

## Test plan

- [x] `pytest tests/test_data.py` — all 116 tests pass (eight existing `test_genome_*` + pickle-roundtrip + storage_options-local-ignored + storage_options-forwarded-to-fsspec + transform/scoring tests that indirectly call `Genome`).
- [x] `pre-commit run --all-files` — ruff lint, ruff format, mypy all clean.
- [x] Hot-loop micro-benchmark (10k calls, 256bp window, small synthetic FASTA): ~450k calls/sec on this machine — orders of magnitude above the issue's ~5 calls/sec bottleneck.
- [x] `multiprocessing.spawn` smoke: workers constructing `Genome` from a path, **and** workers receiving a pickled `Genome` (with `_fa` populated in the parent) — both return correct sequences.
- [x] S3 smoke against `s3://broad-references/hg19/v0/Homo_sapiens_assembly19.fasta` with `Genome(url, storage_options={"anon": True})`: 85 chroms enumerated in 0.68 s; 256 bp read at chr1:1 Mb in ~1.7 s; cached reverse-complement of the same region in 0.1 ms.
- [x] **End-to-end on real GRCh38 + a small HF model (HyenaDNA-tiny) on an A10G** (g5.xlarge via SkyPilot, same instance class as the issue's reproducer). With `pd.options.future.infer_string = True` to match the bottleneck conditions:

  | Metric (chr1-subset) | `main` | this PR | speedup |
  |---|---:|---:|---:|
  | `Genome.__call__` throughput (256 bp window) | **3 calls/sec** | **2,966 calls/sec** | **~990×** |
  | End-to-end LLR over 200 variants (HyenaDNA-tiny, bs=64, 4 dataloader workers) | **28.3 s** (7.1 var/sec) | **1.3 s** (151 var/sec) | **~22×** |
  | `Genome()` init (chr1 only, ~250 MB) | 20.7 s | 19.4 s (dominated by first-time `.fai` build) | — |

  Also: the full GRCh38 genome on `main` **OOM-killed** the 16 GB g5.xlarge during eager load (13.3 GB resident in `pandas`); the PR runs fine on the same instance since it never materializes the sequences in memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
